### PR TITLE
add an option page to configure IgnoreLeadingAndTrailingWhiteSpace

### DIFF
--- a/Source/EditorMargin.cs
+++ b/Source/EditorMargin.cs
@@ -273,6 +273,7 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
                 case MarginDrawReason.TextViewTextChanged:
                 case MarginDrawReason.TextViewLayoutChanged:
                 case MarginDrawReason.EditorFormatMapChanged:
+                case MarginDrawReason.GeneralSettingsChanged:
                     DrawMargins(e.DiffLines);
                     break;
 

--- a/Source/MarginCore.cs
+++ b/Source/MarginCore.cs
@@ -416,11 +416,11 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
         /// <param name="modifiedStream">Modified stream.</param>
         /// <param name="modifiedEncoding">Encoding of modified stream.</param>
         /// <returns>A summary of the differences between two streams.</returns>
-        private static DiffSummary GetDifference(Stream originalStream, Encoding originalEncoding, Stream modifiedStream, Encoding modifiedEncoding)
+        private DiffSummary GetDifference(Stream originalStream, Encoding originalEncoding, Stream modifiedStream, Encoding modifiedEncoding)
         {
             var diffOptions = new DiffOptions { UseThirdPartyTool = false };
 
-            if (TfsPendingChangesMarginPackage.IgnoreLeadingAndTrailingWhiteSpace)
+            if (_marginSettings.IgnoreLeadingAndTrailingWhiteSpace)
                 diffOptions.Flags |= DiffOptionFlags.IgnoreLeadingAndTrailingWhiteSpace;
 
             originalStream.Position = 0;
@@ -481,6 +481,7 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
                 _textView.ZoomLevelChanged += OnTextViewZoomLevelChanged;
                 _textDoc.FileActionOccurred += OnTextDocFileActionOccurred;
                 _formatMap.FormatMappingChanged += OnFormatMapFormatMappingChanged;
+                TfsPendingChangesMarginPackage.GeneralSettingsChanged += OnGeneralSettingsChanged;
                 _versionControl.CommitCheckin += OnVersionControlCommitCheckin;
                 _scrollMap.MappingChanged += OnScrollMapMappingChanged;
 
@@ -495,6 +496,7 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
                 _textView.ZoomLevelChanged -= OnTextViewZoomLevelChanged;
                 _textDoc.FileActionOccurred -= OnTextDocFileActionOccurred;
                 _formatMap.FormatMappingChanged -= OnFormatMapFormatMappingChanged;
+                TfsPendingChangesMarginPackage.GeneralSettingsChanged -= OnGeneralSettingsChanged;
                 _versionControl.CommitCheckin -= OnVersionControlCommitCheckin;
                 _scrollMap.MappingChanged -= OnScrollMapMappingChanged;
 
@@ -828,6 +830,18 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
         {
             _marginSettings.Refresh();
             Redraw(true, MarginDrawReason.EditorFormatMapChanged);
+        }
+
+        /// <summary>
+        /// Event handler called when settings are changed on the <see cref="Settings.GeneralSettingsPage"/>.
+        /// </summary>
+        private void OnGeneralSettingsChanged()
+        {
+            _marginSettings.Refresh();
+
+            // Note that because the IgnoreLeadingAndTrailingWhiteSpace setting can change which
+            // lines are considered to have been modified, the useCache parameter must be false.
+            Redraw(false, MarginDrawReason.GeneralSettingsChanged);
         }
 
         /// <summary>

--- a/Source/MarginCore.cs
+++ b/Source/MarginCore.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 using AlekseyNagovitsyn.TfsPendingChangesMargin.Settings;
 
@@ -420,8 +420,8 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
         {
             var diffOptions = new DiffOptions { UseThirdPartyTool = false };
 
-            // TODO: make flag IgnoreLeadingAndTrailingWhiteSpace configurable via "Tools|Options..." dialog (TfsPendingChangesMargin settings).
-            diffOptions.Flags = diffOptions.Flags | DiffOptionFlags.IgnoreLeadingAndTrailingWhiteSpace;
+            if (TfsPendingChangesMarginPackage.IgnoreLeadingAndTrailingWhiteSpace)
+                diffOptions.Flags |= DiffOptionFlags.IgnoreLeadingAndTrailingWhiteSpace;
 
             originalStream.Position = 0;
             modifiedStream.Position = 0;

--- a/Source/MarginDrawReason.cs
+++ b/Source/MarginDrawReason.cs
@@ -44,6 +44,11 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
         EditorFormatMapChanged,
 
         /// <summary>
+        /// A setting on the <see cref="Settings.GeneralSettingsPage"/> has been changed.
+        /// </summary>
+        GeneralSettingsChanged,
+
+        /// <summary>
         /// The mapping has been changed between a character position and its vertical fraction.
         /// </summary>
         ScrollMapMappingChanged

--- a/Source/ScrollbarMargin.cs
+++ b/Source/ScrollbarMargin.cs
@@ -163,6 +163,7 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
                 case MarginDrawReason.TextDocFileActionOccurred:
                 case MarginDrawReason.TextViewTextChanged:
                 case MarginDrawReason.EditorFormatMapChanged:
+                case MarginDrawReason.GeneralSettingsChanged:
                 case MarginDrawReason.ScrollMapMappingChanged:
                     DrawMargins(e.DiffLines);
                     break;

--- a/Source/Settings/GeneralSettingsPage.cs
+++ b/Source/Settings/GeneralSettingsPage.cs
@@ -10,24 +10,32 @@ using Microsoft.VisualStudio.Shell;
 namespace AlekseyNagovitsyn.TfsPendingChangesMargin.Settings
 {
     /// <summary>
-    /// This page is a basic grid including any settings used by the TfsPendingChangesMargin extension.
+    /// This page is a basic grid including any non-format related settings used by this extension.
     /// 
     /// The ProvideOptionPageAttribute on the TfsPendingChangesMarginPackage is used to add this page
     /// to the Visual Studio Tools-> Options dialog.
     /// </summary>
     [ClassInterface(ClassInterfaceType.AutoDual)]
     [CLSCompliant(false), ComVisible(true)]
-    public class OptionPage : DialogPage
+    public class GeneralSettingsPage : DialogPage
     {
         [Category("Diff Options")]
         [DisplayName("Ignore leading and trailing white space")]
         [Description("If True, the margin will not show lines where the only changes are to leading or trailing white space")]
         public bool IgnoreLeadingAndTrailingWhiteSpace { get; set; }
 
-        public OptionPage()
+        public GeneralSettingsPage()
         {
             // TODO: in C# 6, default values for properties can be specified inline so this constructor can be removed
             IgnoreLeadingAndTrailingWhiteSpace = true;
+        }
+
+        protected override void OnApply(PageApplyEventArgs e)
+        {
+            base.OnApply(e);
+
+            if (e.ApplyBehavior == ApplyKind.Apply)
+                TfsPendingChangesMarginPackage.RaiseGeneralSettingsChanged();
         }
     }
 }

--- a/Source/Settings/MarginSettings.cs
+++ b/Source/Settings/MarginSettings.cs
@@ -30,6 +30,12 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin.Settings
         public Brush RemovedLineMarginBrush { get; set; }
 
         /// <summary>
+        /// If true, the margin will not show lines where the only changes are to leading or trailing white space.
+        /// </summary>
+        /// <remarks>This is configured on the <see cref="Settings.GeneralSettingsPage"/></remarks>
+        public bool IgnoreLeadingAndTrailingWhiteSpace { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of margin settings.
         /// </summary>
         /// <param name="formatMap">Map that contains format definitions for Visual Studio editor.</param>
@@ -47,6 +53,9 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin.Settings
             AddedLineMarginBrush = _formatMap.GetForeground<AddedLineMarginFormatDefinition>();
             ModifiedLineMarginBrush = _formatMap.GetForeground<ModifiedLineMarginFormatDefinition>();
             RemovedLineMarginBrush = _formatMap.GetForeground<RemovedLineMarginFormatDefinition>();
+
+            var generalSettings = TfsPendingChangesMarginPackage.GetGeneralSettings();
+            IgnoreLeadingAndTrailingWhiteSpace = (bool)generalSettings.Item("IgnoreLeadingAndTrailingWhiteSpace").Value;
         }
     }
 }

--- a/Source/Settings/OptionPage.cs
+++ b/Source/Settings/OptionPage.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+
+namespace AlekseyNagovitsyn.TfsPendingChangesMargin.Settings
+{
+    /// <summary>
+    /// This page is a basic grid including any settings used by the TfsPendingChangesMargin extension.
+    /// 
+    /// The ProvideOptionPageAttribute on the TfsPendingChangesMarginPackage is used to add this page
+    /// to the Visual Studio Tools-> Options dialog.
+    /// </summary>
+    [ClassInterface(ClassInterfaceType.AutoDual)]
+    [CLSCompliant(false), ComVisible(true)]
+    public class OptionPage : DialogPage
+    {
+        [Category("Diff Options")]
+        [DisplayName("Ignore leading and trailing white space")]
+        [Description("If True, the margin will not show lines where the only changes are to leading or trailing white space")]
+        public bool IgnoreLeadingAndTrailingWhiteSpace { get; set; }
+
+        public OptionPage()
+        {
+            // TODO: in C# 6, default values for properties can be specified inline so this constructor can be removed
+            IgnoreLeadingAndTrailingWhiteSpace = true;
+        }
+    }
+}

--- a/Source/TfsPendingChangesMargin.csproj
+++ b/Source/TfsPendingChangesMargin.csproj
@@ -96,7 +96,7 @@
     <Compile Include="Settings\EditorFormatMapExtensions.cs" />
     <Compile Include="Settings\MarginSettings.cs" />
     <Compile Include="Settings\ModifiedLineMarginFormatDefinition.cs" />
-    <Compile Include="Settings\OptionPage.cs">
+    <Compile Include="Settings\GeneralSettingsPage.cs">
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Settings\RemovedLineMarginFormatDefinition.cs" />

--- a/Source/TfsPendingChangesMargin.csproj
+++ b/Source/TfsPendingChangesMargin.csproj
@@ -11,7 +11,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>10.0.20305</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{C15332BB-CC7E-4E69-A6F1-0E114AFAFFF9}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -19,7 +19,6 @@
     <AssemblyName>TfsPendingChangesMargin</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <GeneratePkgDefFile>false</GeneratePkgDefFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,8 +51,14 @@
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Client, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Common, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
     <Reference Include="Microsoft.VisualStudio.Services.Common, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.12.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
     <Reference Include="Microsoft.VisualStudio.TeamFoundation, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
@@ -64,6 +69,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -90,7 +96,11 @@
     <Compile Include="Settings\EditorFormatMapExtensions.cs" />
     <Compile Include="Settings\MarginSettings.cs" />
     <Compile Include="Settings\ModifiedLineMarginFormatDefinition.cs" />
+    <Compile Include="Settings\OptionPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Settings\RemovedLineMarginFormatDefinition.cs" />
+    <Compile Include="TfsPendingChangesMarginPackage.cs" />
     <Compile Include="VersionControlItemNotFoundException.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -121,7 +131,15 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="VSPackage.resx">
+      <MergeWithCTO>true</MergeWithCTO>
+      <ManifestResourceName>VSPackage</ManifestResourceName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
+  <PropertyGroup>
+    <UseCodebase>true</UseCodebase>
+  </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/TfsPendingChangesMarginPackage.cs
+++ b/Source/TfsPendingChangesMarginPackage.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+
+namespace AlekseyNagovitsyn.TfsPendingChangesMargin
+{
+    /// <summary>
+    /// This is the class that implements the package exposed by this assembly.
+    ///
+    /// The minimum requirement for a class to be considered a valid package for Visual Studio
+    /// is to implement the IVsPackage interface and register itself with the shell.
+    /// This package uses the helper classes defined inside the Managed Package Framework (MPF)
+    /// to do it: it derives from the Package class that provides the implementation of the 
+    /// IVsPackage interface and uses the registration attributes defined in the framework to 
+    /// register itself and its components with the shell.
+    /// </summary>
+    [PackageRegistration(UseManagedResourcesOnly = true)]
+    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
+    [Guid("9ec6e3aa-48cd-4953-b3b7-1a203bfded7f")]
+    [ProvideOptionPage(typeof(Settings.OptionPage), "Tfs Pending Changes Margin", "General", 0, 0, true)]
+    public sealed class TfsPendingChangesMarginPackage : Package
+    {
+        public static bool IgnoreLeadingAndTrailingWhiteSpace
+        {
+            get
+            {
+                var dte = (DTE)GetGlobalService(typeof(DTE));
+                EnvDTE.Properties properties = dte.Properties["Tfs Pending Changes Margin", "General"];
+                return (bool)properties.Item("IgnoreLeadingAndTrailingWhiteSpace").Value;
+            }
+        }
+    }
+}

--- a/Source/TfsPendingChangesMarginPackage.cs
+++ b/Source/TfsPendingChangesMarginPackage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using AlekseyNagovitsyn.TfsPendingChangesMargin.Settings;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 
@@ -18,17 +19,30 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [Guid("9ec6e3aa-48cd-4953-b3b7-1a203bfded7f")]
-    [ProvideOptionPage(typeof(Settings.OptionPage), "Tfs Pending Changes Margin", "General", 0, 0, true)]
+    [ProvideOptionPage(typeof(GeneralSettingsPage), "Tfs Pending Changes Margin", "General", 0, 0, true)]
     public sealed class TfsPendingChangesMarginPackage : Package
     {
-        public static bool IgnoreLeadingAndTrailingWhiteSpace
+        /// <summary>
+        /// Returns the settings from the Tools|Options... dialog's Tfs Pending Changes Margin|General section
+        /// </summary>
+        public static EnvDTE.Properties GetGeneralSettings()
         {
-            get
-            {
-                var dte = (DTE)GetGlobalService(typeof(DTE));
-                EnvDTE.Properties properties = dte.Properties["Tfs Pending Changes Margin", "General"];
-                return (bool)properties.Item("IgnoreLeadingAndTrailingWhiteSpace").Value;
-            }
+            var dte = (DTE)GetGlobalService(typeof(DTE));
+            return dte.Properties["Tfs Pending Changes Margin", "General"];
+        }
+
+        /// <summary>
+        /// Event raised when the settings on the <see cref="GeneralSettingsPage"/> are changed
+        /// </summary>
+        public static event Action GeneralSettingsChanged;
+
+        /// <summary>
+        /// Raises the <see cref="GeneralSettingsChanged"/> event.
+        /// </summary>
+        public static void RaiseGeneralSettingsChanged()
+        {
+            if (GeneralSettingsChanged != null)
+                GeneralSettingsChanged();
         }
     }
 }

--- a/Source/VSPackage.resx
+++ b/Source/VSPackage.resx
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="110" xml:space="preserve">
+    <value>TfsPendingChangesMargin</value>
+  </data>
+  <data name="112" xml:space="preserve">
+    <value>A Visual Studio extension to display TFS Pending Changes on the margin of the current file.</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\Icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>

--- a/Source/source.extension.vsixmanifest
+++ b/Source/source.extension.vsixmanifest
@@ -17,9 +17,11 @@
     <InstallationTarget Version="[12.0,14.0]" Id="Microsoft.VisualStudio.IntegratedShell" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.12.0" DisplayName="Visual Studio MPF 12.0" d:Source="Installed" Version="[12.0]" />
   </Dependencies>
   <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
I have added a page to the "Tools|Options..." dialog for this extension that has a grid of basic settings.  For now it only has the option to toggle the IgnoreLeadingAndTrailingWhiteSpace diff option.

Let me know if you have any questions or comments.