### PR TITLE
Fix margin missing in html/cshtml files (#10)

### DIFF
--- a/Source/MarginCore.cs
+++ b/Source/MarginCore.cs
@@ -195,7 +195,7 @@ namespace AlekseyNagovitsyn.TfsPendingChangesMargin
             Debug.WriteLine("Entering constructor.", Properties.Resources.ProductName);
 
             _textView = textView;
-            if (!textDocumentFactoryService.TryGetTextDocument(_textView.TextBuffer, out _textDoc))
+            if (!textDocumentFactoryService.TryGetTextDocument(_textView.TextDataModel.DocumentBuffer, out _textDoc))
             {
                 Debug.WriteLine("Can not retrieve TextDocument. Margin is disabled.", Properties.Resources.ProductName);
                 _isEnabled = false;


### PR DESCRIPTION
`TextBuffer` is missing in HTML `textView`, while `TextDataModel.DocumentBuffer` is present.

This was tested with VS 2013 Pro Update 4 and TFS 2012.